### PR TITLE
Update Astropy coordinates to latest API

### DIFF
--- a/run_benchmark.py
+++ b/run_benchmark.py
@@ -71,7 +71,7 @@ class CoordinatesBenchmark():
             if report_speed:
                 f_speed.write('%15s %10s %10s %10.6f\n' %
                               (tool, systems['in'], systems['out'], duration))
-            filename = '%s/%s_to_%s.txt' % (tool, systems['in'], systems['out'])
+            filename = 'tools/%s/%s_to_%s.txt' % (tool, systems['in'], systems['out'])
             self._write_coords(filename, out_coords)
 
     @staticmethod

--- a/tools/astropy/convert.py
+++ b/tools/astropy/convert.py
@@ -5,38 +5,24 @@ https://github.com/astropy/astropy
 http://www.astropy.org
 """
 import numpy as np
-from astropy import coordinates as coord
-from astropy.time import Time
-from astropy import units as u
+from astropy.coordinates import SkyCoord
+#from astropy.time import Time
+#from astropy import units as u
 
 SUPPORTED_SYSTEMS = 'fk5 fk4 icrs galactic'.split()
-
-def get_system(system):
-    """Convert generic system specification tags to astropy specific class."""
-    d = dict()
-    d['fk5'] = coord.FK5
-    d['fk4'] = coord.FK4
-    d['icrs'] = coord.ICRS
-    d['galactic'] = coord.Galactic
-    return d[system]
 
 def convert(coords, systems):
 
     if not set(systems.values()).issubset(SUPPORTED_SYSTEMS):
         return None
 
-    skyin, skyout = get_system(systems['in']), get_system(systems['out'])
+    frame_in = systems['in']
+    pos_in = SkyCoord(coords['lon'], coords['lat'], unit='deg', frame=frame_in)
 
-    lons = np.zeros_like(coords['lon'])
-    lats = np.zeros_like(coords['lat'])
+    frame_out = systems['out']
+    pos_out = pos_in.transform_to(frame_out)
 
-    in_coord = skyin(coords['lon'], coords['lat'], unit=(u.degree, u.degree),
-                     obstime=Time('J2000', scale='utc'))
-
-    out_coord = in_coord.transform_to(skyout)
-
-    lons, lats = out_coord.lonangle.degree, out_coord.latangle.degree
-
-    lons = lons % 360.
+    lons = pos_out.data.lon.degree
+    lats = pos_out.data.lat.degree
 
     return dict(lon=lons, lat=lats)


### PR DESCRIPTION
Currently the tests use the Astropy 0.3 API, but we should change the tests to use `SkyCoord`
