### PR TITLE
Fix URL of output plots

### DIFF
--- a/coordinates_benchmark/commands/html.py
+++ b/coordinates_benchmark/commands/html.py
@@ -72,7 +72,7 @@ def _compare_celestial(tool1, tool2, systems, f_txt, f_html):
 
     # Write out to HTML
     color = _accuracy_color(mean)
-    plot_filename = utils.plot_filename(tool1, tool2, systems)
+    plot_filename = utils.plot_filename(tool1, tool2, systems, inc_root_dir=False)
 
     f_html.write("  <tr>\n")
     f_html.write("    <td align='center'>{tool1:10s}</td>\n".format(tool1=tool1))

--- a/coordinates_benchmark/utils.py
+++ b/coordinates_benchmark/utils.py
@@ -163,8 +163,11 @@ def horizontal_filename(tool):
     return fmt.format(tool)
 
 
-def plot_filename(tool1, tool2, systems):
-    fmt = 'output/plots/{}_vs_{}_for_{}_to_{}.png'
+def plot_filename(tool1, tool2, systems, inc_root_dir=True):
+    root_dir = ""
+    if inc_root_dir:
+        root_dir = "output/"
+    fmt = root_dir + 'plots/{}_vs_{}_for_{}_to_{}.png'
     return fmt.format(tool1, tool2, systems['in'], systems['out'])
 
 


### PR DESCRIPTION
The output path for the plots is not the same as the URL for the plots because the HTML is loaded from one level down in the directory hierarchy. This patch allows the URL to be formed without the extra "output".