### PR TITLE
Use ci helpers for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,37 +4,27 @@ python:
     - 2.7
     # - 3.4
 
-before_install:
+sudo: false
 
-    # Use utf8 encoding. Should be default, but this is insurance against
-    # future changes
-    - export PYTHONIOENCODING=UTF8
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - chmod +x miniconda.sh
-    - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda/bin:$PATH
-    - conda update --yes conda
+addons:
+    apt:
+        packages:
+            - gfortran
 
-    # Make sure that interactive matplotlib backends work
-    - export DISPLAY=:99.0
-    - sh -e /etc/init.d/xvfb start
-
-    # Make sure matplotlib uses PyQT not PySide
-    - export QT_API=pyqt
-
-    # Install gfortran for pyslalib
-    - sudo apt-get install gfortran
+env:
+    global:
+        - ASTROPY_VERSION=dev
+        - CONDA_DEPENDENCIES='click matplotlib'
+        - PIP_DEPENDENCIES='pytpm novas pyephem starlink-pyast palpy'
+        - SETUP_XVFB=True
 
 install:
-
-    # CONDA
-    - conda create --yes -n test -c astropy-ci-extras python=$TRAVIS_PYTHON_VERSION
-    - source activate test
-
-    # CORE DEPENDENCIES
-    - conda install --yes numpy pip Cython jinja2 pyqt matplotlib
-    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install -r requirements.txt; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.4 ]]; then pip install -r requirements_python3.txt; fi
+    - git clone git://github.com/astropy/ci-helpers.git
+    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+    - pip install https://github.com/scottransom/pyslalib/archive/master.zip
+    - if [[ $TRAVIS_PYTHON_VERSION == 2.* ]]; then
+        pip install http://www.astro.rug.nl/software/kapteyn/kapteyn-2.2.tar.gz;
+      fi
 
 script:
     - ./make.py --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
     - pip install https://github.com/scottransom/pyslalib/archive/master.zip
     - if [[ $TRAVIS_PYTHON_VERSION == 2.* ]]; then
-        pip install http://www.astro.rug.nl/software/kapteyn/kapteyn-2.2.tar.gz;
+        pip install http://www.astro.rug.nl/software/kapteyn/kapteyn-2.3.tar.gz;
       fi
 
 script:


### PR DESCRIPTION
This fixes .travis.yml to use ci-helpers and updates Kapteyn to 2.3