### PR TITLE
Enable ecliptic for astropy

### DIFF
--- a/coordinates_benchmark/tools/astropy.py
+++ b/coordinates_benchmark/tools/astropy.py
@@ -12,7 +12,7 @@ from astropy import coordinates as coord
 from astropy.time import Time
 from astropy import units as u
 
-SUPPORTED_SYSTEMS = 'fk5 fk4 icrs galactic'.split()
+SUPPORTED_SYSTEMS = 'fk5 fk4 icrs galactic ecliptic'.split()
 
 
 def get_system(system):
@@ -22,6 +22,7 @@ def get_system(system):
     d['fk4'] = coord.FK4
     d['icrs'] = coord.ICRS
     d['galactic'] = coord.Galactic
+    d['ecliptic'] = coord.BarycentricTrueEcliptic
     return d[system]
 
 


### PR DESCRIPTION
This tweak enables ecliptic transformations from astropy. The main issue being that Astropy seems to give discrepant answers of order 15 arcsec (in longitude, latitude is fine). I assume this is all expected because there is a test in astropy comparing ecliptic to pytpm and the test passes if the discrepancy is less than one arcminute. Most of the other systems agree with each other much better than that (although I need to also do a PR to fix problems in pytpm ecliptic).

@eteq I see from astropy/astropy#3749 that you were intending to update the benchmarks but I don't see that change. One complication is that SLALIB et al only seem to have one definition of Barycentric but I get the ~15 arcsec error for both barycentric and geocentric ecliptic.