### PR TITLE
Make Skyfield correct for polar motion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ env
 
 # Files downloaded by Skyfield
 de430.bsp
+finals2000A.all

--- a/coordinates_benchmark/tools/skyfield.py
+++ b/coordinates_benchmark/tools/skyfield.py
@@ -8,7 +8,7 @@ https://rhodesmill.org/skyfield/
 from __future__ import absolute_import, division, print_function
 
 from skyfield.units import Angle
-from skyfield.api import Star, wgs84, load
+from skyfield.api import Star, wgs84, Loader
 from skyfield.data import iers
 from astropy.time import Time
 from astropy.table import Table
@@ -23,6 +23,13 @@ def _convert_radec_to_altaz(ra, dec, lon, lat, height, time):
     This is done for easy code sharing with other tools.
     Skyfield does support arrays of positions.
     """
+    load = Loader('.')
+    # Skyfield uses FTP URLs, but FTP doesn't work on Github Actions so
+    # we use alternative HTTP URLs.
+    load.urls['finals2000A.all'] = 'https://datacenter.iers.org/data/9/'
+    load.urls['.bsp'] = [
+        ('*.bsp', 'https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/')
+    ]
 
     radec = Star(ra=Angle(degrees=ra), dec=Angle(degrees=dec))
 
@@ -32,9 +39,7 @@ def _convert_radec_to_altaz(ra, dec, lon, lat, height, time):
                                     elevation_m=height * 1000.0)
 
     ts = load.timescale(builtin=False)
-    # Skyfield uses an FTP URL, but FTP doesn't work on Travis so we use an
-    # alternative HTTP URL.
-    with load.open('https://datacenter.iers.org/data/9/finals2000A.all') as f:
+    with load.open('finals2000A.all') as f:
         finals_data = iers.parse_x_y_dut1_from_finals_all(f)
     iers.install_polar_motion_table(ts, finals_data)
     obstime = ts.from_astropy(Time(time, scale='utc'))

--- a/coordinates_benchmark/tools/skyfield.py
+++ b/coordinates_benchmark/tools/skyfield.py
@@ -8,7 +8,7 @@ https://rhodesmill.org/skyfield/
 from __future__ import absolute_import, division, print_function
 
 from skyfield.units import Angle
-from skyfield.api import Star, Topos, load
+from skyfield.api import Star, wgs84, load
 from skyfield.data import iers
 from astropy.time import Time
 from astropy.table import Table
@@ -27,9 +27,9 @@ def _convert_radec_to_altaz(ra, dec, lon, lat, height, time):
     radec = Star(ra=Angle(degrees=ra), dec=Angle(degrees=dec))
 
     earth = load(EPHEMERIS)['earth']
-    location = earth + Topos(longitude_degrees=lon,
-                             latitude_degrees=lat,
-                             elevation_m=height * 1000.0)
+    location = earth + wgs84.latlon(longitude_degrees=lon,
+                                    latitude_degrees=lat,
+                                    elevation_m=height * 1000.0)
 
     ts = load.timescale(builtin=False)
     with load.open('finals2000A.all') as f:

--- a/coordinates_benchmark/tools/skyfield.py
+++ b/coordinates_benchmark/tools/skyfield.py
@@ -32,7 +32,9 @@ def _convert_radec_to_altaz(ra, dec, lon, lat, height, time):
                                     elevation_m=height * 1000.0)
 
     ts = load.timescale(builtin=False)
-    with load.open('finals2000A.all') as f:
+    # Skyfield uses an FTP URL, but FTP doesn't work on Travis so we use an
+    # alternative HTTP URL.
+    with load.open('https://datacenter.iers.org/data/9/finals2000A.all') as f:
         finals_data = iers.parse_x_y_dut1_from_finals_all(f)
     iers.install_polar_motion_table(ts, finals_data)
     obstime = ts.from_astropy(Time(time, scale='utc'))

--- a/coordinates_benchmark/tools/skyfield.py
+++ b/coordinates_benchmark/tools/skyfield.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function
 
 from skyfield.units import Angle
 from skyfield.api import Star, Topos, load
+from skyfield.data import iers
 from astropy.time import Time
 from astropy.table import Table
 
@@ -30,7 +31,10 @@ def _convert_radec_to_altaz(ra, dec, lon, lat, height, time):
                              latitude_degrees=lat,
                              elevation_m=height * 1000.0)
 
-    ts = load.timescale()
+    ts = load.timescale(builtin=False)
+    with load.open('finals2000A.all') as f:
+        finals_data = iers.parse_x_y_dut1_from_finals_all(f)
+    iers.install_polar_motion_table(ts, finals_data)
     obstime = ts.from_astropy(Time(time, scale='utc'))
 
     alt, az, _ = location.at(obstime).observe(radec).apparent().altaz(pressure_mbar=0)


### PR DESCRIPTION
By default Skyfield doesn't correct for polar motion; it needs to be
told to fetch the IERS tables.

With this correction, horizontal coordinates are consistent with astropy
at the milli-arcsec level (except for dates that preceed the coverage of
the polar motion tables, where astropy complains).