### PR TITLE
MNT: Replace master with main

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -5,9 +5,9 @@ name: Run benchmarks
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   benchmark:
@@ -60,7 +60,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [benchmark]
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
     - name: Download results
       uses: actions/download-artifact@v2

--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,9 @@ For now we only compare precision, in the future we also want to compare speed.
     :target: https://github.com/astropy/coordinates-benchmark/actions?query=workflow%3A%22Run+benchmarks%22
     :alt: Benchmarks Status
 
-Documentation is in the `docs <https://github.com/astropy/coordinates-benchmark/blob/master/docs/>`__ folder:
+Documentation is in the `docs <https://github.com/astropy/coordinates-benchmark/blob/main/docs/>`__ folder:
 
-- `Specification.rst <https://github.com/astropy/coordinates-benchmark/blob/master/docs/Specification.rst>`_
-- `Notes.rst <https://github.com/astropy/coordinates-benchmark/blob/master/docs/Notes.rst>`_
-- `Tools.rst <https://github.com/astropy/coordinates-benchmark/blob/master/docs/Tools.rst>`_
-- `HOWTO.rst <https://github.com/astropy/coordinates-benchmark/blob/master/docs/HOWTO.rst>`_
+- `Specification.rst <https://github.com/astropy/coordinates-benchmark/blob/main/docs/Specification.rst>`_
+- `Notes.rst <https://github.com/astropy/coordinates-benchmark/blob/main/docs/Notes.rst>`_
+- `Tools.rst <https://github.com/astropy/coordinates-benchmark/blob/main/docs/Tools.rst>`_
+- `HOWTO.rst <https://github.com/astropy/coordinates-benchmark/blob/main/docs/HOWTO.rst>`_

--- a/docs/Tools.rst
+++ b/docs/Tools.rst
@@ -66,7 +66,7 @@ PyTPM
 `TPM <http://www.sal.wisc.edu/~jwp/astro/tpm/tpm.html>`_ C library with a high-level
 ``convert.convertv6`` function interface. Unmaintained.
 
-We are using the version from github master.
+We are using the version from github main.
 
 Note that ``pytpm`` is unmaintained and is known to give incorrect results in this case:
 https://github.com/phn/pytpm/issues/2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-https://github.com/astrojuanlu/pytpm/archive/main.zip; python_version >= "3"
+https://github.com/astrojuanlu/pytpm/archive/master.zip; python_version >= "3"
 git+http://github.com/astropy/astropy.git#egg=astropy
 novas
 pyephem
-https://github.com/scottransom/pyslalib/archive/main.zip
+https://github.com/scottransom/pyslalib/archive/master.zip
 starlink-pyast
 palpy
 kapteyn<=2.3; python_version < "3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-https://github.com/astrojuanlu/pytpm/archive/master.zip; python_version >= "3"
+https://github.com/astrojuanlu/pytpm/archive/main.zip; python_version >= "3"
 git+http://github.com/astropy/astropy.git#egg=astropy
 novas
 pyephem
-https://github.com/scottransom/pyslalib/archive/master.zip
+https://github.com/scottransom/pyslalib/archive/main.zip
 starlink-pyast
 palpy
 kapteyn<=2.3; python_version < "3"


### PR DESCRIPTION
This PR attempts to replace all mention of `master` to `main` in this repository. This should be reviewed and merged right after the maintainer has renamed the default branch.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

This is part of #76 